### PR TITLE
Fix null pointer dereferencing

### DIFF
--- a/strife-ve-src/src/i_main.c
+++ b/strife-ve-src/src/i_main.c
@@ -156,6 +156,8 @@ int main(int argc, char **argv)
     // Edward [SVE]: Speed things up
     I_SetCPUHighPerformance(1);
 
+    I_InitAppServices();
+
     // Only schedule on a single core, if we have multiple
     // cores.  This is to work around a bug in SDL_mixer.
     // [SVE]: this should not be needed any more.


### PR DESCRIPTION
I compiled the engine on Debian 12. The game always crashed when receiving the comm unit from Rowan.
gdb gave me the following output:
```
Thread 1 "strife-toe" received signal SIGSEGV, Segmentation fault.
0x00005555555ca8e9 in P_DialogDoChoice (choice=0) at /home/user/repos/strife-the-order-edition/strife-ve-src/src/strife/p_dialog.c:1514
1514                    gAppServices->SetAchievement("SVE_ACH_SILENCE_IS_GOLDEN");
```
After checking the code and comparing it to the upstream repo, I realized that there was a missing call to `I_InitAppServices()`, so `gAppServices` was not being set.
Adding back the call fixed the issue.